### PR TITLE
adding entity_kind to __init__.py

### DIFF
--- a/entity/__init__.py
+++ b/entity/__init__.py
@@ -2,4 +2,4 @@
 from .config import EntityConfig, entity_registry, register_entity
 from .version import __version__
 from .tasks import SyncEntitiesTask
-from .models import Entity, EntityRelationship, turn_on_syncing, turn_off_syncing, sync_entities
+from .models import Entity, EntityKind, EntityRelationship, turn_on_syncing, turn_off_syncing, sync_entities


### PR DESCRIPTION
This pull request adds EntityKind to the **init**.py file so that we can do

from entity import EntityKind
instead of
from entity.models import EntityKind
