### PR TITLE
Page the queryset instead of iterate

### DIFF
--- a/entity/tests/sync_tests.py
+++ b/entity/tests/sync_tests.py
@@ -871,7 +871,7 @@ class TestCachingAndCascading(EntityTestCase):
         with patch('entity.sync.entity_registry') as mock_entity_registry:
             mock_entity_registry.entity_registry = new_registry.entity_registry
             ContentType.objects.clear_cache()
-            with self.assertNumQueries(18):
+            with self.assertNumQueries(20):
                 sync_entities()
 
         self.assertEquals(Entity.objects.filter(entity_type=ContentType.objects.get_for_model(Account)).count(), 5)


### PR DESCRIPTION
This will still allow prefetch_related calls while keeping memory low. @wesleykendall 