### PR TITLE
adding AllEntityProxy

### DIFF
--- a/entity/models.py
+++ b/entity/models.py
@@ -442,6 +442,22 @@ class EntityGroup(models.Model):
         return self.bulk_add_entities(entities_and_kinds)
 
 
+@compare_on_attr()
+class AllEntityProxy(Entity):
+    """
+    This is a proxy of the entity class that makes the .objects attribute
+    access all of the entities regardless of active state.  Active entities
+    are accessed with the active_objects manager.  This proxy should be used
+    when you need foreign-key relationships to be able to access all entities
+    regardless of active state.
+    """
+    objects = AllEntityManager()
+    active_objects = ActiveEntityManager()
+
+    class Meta:
+        proxy = True
+
+
 class EntityGroupMembership(models.Model):
     """Membership information for entity groups.
 


### PR DESCRIPTION
The default model manager for Entity ignores inactive entities.  This is a problem because foreign key relationships use the default manager.  Django is stupid in that the default manager is the ONLY manager it uses for this case.

This PR creates a proxy model that is identical to Entity, except that is uses a default manager, which includes all entities by default.  It adds additional manager called `active_entities` to grab only active entities.